### PR TITLE
Se agrega mejor manejo para las Opciones de pago

### DIFF
--- a/Model/Config/Source/FinancialPlans.php
+++ b/Model/Config/Source/FinancialPlans.php
@@ -34,7 +34,7 @@ class FinancialPlans implements OptionSourceInterface
      *
      * @return array
      */
-    public function toArray()
+    public function toArray(): array
     {
         return array_map(function ($item) {
             return [$item['value'] => $item['label']];
@@ -46,13 +46,14 @@ class FinancialPlans implements OptionSourceInterface
      *
      * @return array
      */
-    public function toOptionArray()
+    public function toOptionArray(): array
     {
         $items = [];
-        foreach ($this->wibondApi->getPlanOptions() as $option) {
+        $options = $this->wibondApi->getPlanOptions();
+        foreach ($options as $option) {
             $items[] = [
                 'value' => $option['id'],
-                'label' => $option['name'],
+                'label' => $option['name'] ?? '(' . $option['code'] . ')',
             ];
         }
         return $items;

--- a/composer.json
+++ b/composer.json
@@ -3,9 +3,9 @@
   "description": "Pagá en cuotas con Wibond.",
   "type": "magento2-module",
   "license": "OSL-3.0",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "require": {
-    "php": "~7.3.0||~7.4.0||~8.0||~8.1||~8.2||~8.3",
+    "php": "~7.4.0||~8.0||~8.1||~8.2||~8.3",
     "magento/framework": "*",
     "magento/module-payment": "*"
   },


### PR DESCRIPTION
Si una opción de pago es devuelta por la API sin valor en el campo name, si mostrará el valor del campo code en la configuración. Esto deberá permitir configurar el módulo correctamente, a pesar del label usado.

Además, si quitó compatibilidad con PHP 7.3 ya que las propiedades tipadas sólo se pueden usar desde PHP 7.4 en adelante.