### PR TITLE
Cambio en la comparación de paymentLinkId y relatedPaymentLinkId para…

### DIFF
--- a/Controller/Notification/Index.php
+++ b/Controller/Notification/Index.php
@@ -117,6 +117,7 @@ class Index implements HttpPostActionInterface, HttpGetActionInterface, CsrfAwar
     public function execute()
     {
         $data = $this->request->getBodyParams();
+
         $this->logger->log('Notification response', $data);
 
         $orderId = $data['externalId'];
@@ -140,7 +141,8 @@ class Index implements HttpPostActionInterface, HttpGetActionInterface, CsrfAwar
         $payment = $order->getPayment();
 
         $paymentLinkId = $payment->getAdditionalInformation(Config::KEY_WIBOND_LINK_ID);
-        if ($paymentLinkId !== $data['relatedPaymentLinkId']) {
+        $relatedPaymentLinkId = (integer)$data['relatedPaymentLinkId'];
+        if ($paymentLinkId !== $relatedPaymentLinkId) {
             $this->logger->log('Invalid payment link id', [$paymentLinkId]);
             throw new LocalizedException(__('Invalid payment link id'));
         }

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Pagá en cuotas con Wibond.",
   "type": "magento2-module",
   "license": "OSL-3.0",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "require": {
     "php": "~7.4.0||~8.0||~8.1||~8.2||~8.3",
     "magento/framework": "*",


### PR DESCRIPTION
… confirmar que son enteros

Este PR va a evitar diferencias en los tipos de datos, que ahora consideraba `paymentLinkId` como integer y `relatedPaymentLinkId` como string.
